### PR TITLE
fixes #102

### DIFF
--- a/src/api/class-template-tags-request.php
+++ b/src/api/class-template-tags-request.php
@@ -58,7 +58,7 @@ class Template_Tags_Request implements Service {
 
 		$tags_decoded = json_decode( wp_remote_retrieve_body( $tags_response ), true );
 
-		$template_tags = [
+		return [
 			'subject_tags' => $tags_decoded['Subject'],
 			'allowed_tags' => array_merge(
 				...array_values(
@@ -66,7 +66,5 @@ class Template_Tags_Request implements Service {
 				)
 			),
 		];
-
-		return $template_tags;
 	}
 }

--- a/src/api/class-template-tags-request.php
+++ b/src/api/class-template-tags-request.php
@@ -56,25 +56,16 @@ class Template_Tags_Request implements Service {
 			throw Api_Response_Error::message( $tags_response->get_error_message() );
 		}
 
-		$template_tags_json = wp_remote_retrieve_body( $tags_response );
+		$tags_decoded = json_decode( wp_remote_retrieve_body( $tags_response ), true );
 
-		$template_tags = [];
-
-		foreach ( json_decode( $template_tags_json, true ) as $tag_category => $tags ) {
-			switch ( $tag_category ) {
-				case 'Subject':
-					$template_tags['subject_tags'] = $tags;
-					break;
-
-				case 'Layout':
-					$template_tags['allowed_tags'] = $tags;
-					break;
-
-				default:
-					$template_tags['allowed_tags'] = array_merge( $template_tags['allowed_tags'], $tags );
-					break;
-			}
-		}
+		$template_tags = [
+			'subject_tags' => $tags_decoded['Subject'],
+			'allowed_tags' => array_merge(
+				...array_values(
+					array_diff_key( $tags_decoded, array_flip( [ 'Subject' ] ) )
+				)
+			),
+		];
 
 		return $template_tags;
 	}

--- a/src/callback/class-run-sniffer-callback.php
+++ b/src/callback/class-run-sniffer-callback.php
@@ -513,23 +513,6 @@ final class Run_Sniffer_Callback extends Base_Ajax_Callback {
 
 		$runner->config = new Config( $config_args );
 
-		// Set default standard.
-		PHPCSHelper::set_config_data( self::DEFAULT_STANDARD, $this->get_default_standard(), true );
-
-		// Ignoring warnings when generating the exit code.
-		PHPCSHelper::set_config_data( self::IGNORE_WARNINGS_ON_EXIT, true, true );
-
-		// Set minimum supported PHP version.
-		PHPCSHelper::set_config_data( self::TEST_VERSION, $minimum_php_version . '-', true );
-
-		// Set text domains.
-		PHPCSHelper::set_config_data( self::TEXT_DOMAIN, implode( ',', $args[ self::TEXT_DOMAINS ] ), true );
-
-		if ( $theme_prefixes !== '' ) {
-			// Set prefix.
-			PHPCSHelper::set_config_data( self::PREFIXES, $theme_prefixes, true );
-		}
-
 		$all_files = array_values( $all_files );
 
 		$runner->config->standards   = $standards_array;
@@ -549,7 +532,25 @@ final class Run_Sniffer_Callback extends Base_Ajax_Callback {
 
 		$runner->init();
 
+		// Set default standard.
+		PHPCSHelper::set_config_data( self::DEFAULT_STANDARD, $this->get_default_standard(), true );
+
+		// Ignoring warnings when generating the exit code.
+		PHPCSHelper::set_config_data( self::IGNORE_WARNINGS_ON_EXIT, true, true );
+
+		// Set minimum supported PHP version.
+		PHPCSHelper::set_config_data( self::TEST_VERSION, $minimum_php_version . '-', true );
+
+		// Set text domains.
+		PHPCSHelper::set_config_data( self::TEXT_DOMAIN, implode( ',', $args[ self::TEXT_DOMAINS ] ), true );
+
+		if ( $theme_prefixes !== '' ) {
+			// Set prefix.
+			PHPCSHelper::set_config_data( self::PREFIXES, $theme_prefixes, true );
+		}
+
 		$runner->reporter = new Reporter( $runner->config );
+
 		foreach ( $all_files as $file_path ) {
 			$file       = new DummyFile( file_get_contents( $file_path ), $runner->ruleset, $runner->config );
 			$file->path = $file_path;


### PR DESCRIPTION
@dingo-d it looks like the testVersion config set in the wptrt ruleset.xml is overriding the cli --runtime-set for testVersion.  Removing the testVersion from the xml showed this to be true.  

Upon looking into the runner, it looks like it needs to be initialized first, and then set the set_config_data calls will work as expected.