### PR TITLE
Feature/js syntax check

### DIFF
--- a/assets/dev/scripts/utils/sniff-js.js
+++ b/assets/dev/scripts/utils/sniff-js.js
@@ -1,0 +1,101 @@
+/**
+ * Sniff a JavaScript file.
+ *
+ * @since 1.1.0
+ *
+ * @prop {string} path                - File's Path relative to WordPress' ABSPATH.
+ * @prop {object} fileObject          - ThemeSniffer file sniff object.
+ * @prop {object} fileObject.filePath - Absolute path to file to sniff.
+ * @prop {object} fileObject.errors   - Total errors on file to sniff.
+ * @prop {array}  fileObject.messages - ThemeSniffer Error message objects for ouput.
+ *
+ * @type {SniffJs}
+ */
+export class SniffJs {
+
+	/**
+	 * Set object properties and instantiate.
+	 *
+	 * @param {Object} fileObject ThemeSniffer file sniff object.
+	 *
+	 * @since 1.1.0
+	 */
+	constructor( fileObject ) {
+		this.fileObject = fileObject;
+		// Seems like syntax errors or empty results cause phpcs to provide a non-number for error count.
+		this.fileObject.errors = isNaN( this.fileObject.errors ) ? 0 : parseInt( this.fileObject.errors, 10 );
+		this.path = this.getPath();
+	}
+
+	/**
+	 * Get relative path to WordPress' ABSPATH from absolute path.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return {string} Relative path from ABSPATH.
+	 */
+	getPath() {
+		let jsFile = this.fileObject.filePath.split( /((?:[^/]*\/)*)(.*)\/themes\//gmi ),
+			fp = jsFile.pop(), // Filepath relative to wp-content/themes/.
+			wpContent = jsFile.pop(); // Name of wpContent folder.
+		return `/${ wpContent }/themes/${ fp }`;
+	}
+
+	/**
+	 * Format Espirma errors for ThemeSniffer consumption.
+	 *
+	 * @param {Object} err An Espirma error.
+	 *
+	 * @since 1.1.0
+	 */
+	format( err ) {
+		this.fileObject.errors++;
+		this.fileObject.messages.push(
+			{
+				line: err.lineNumber,
+				column: err.column,
+				message: err.description,
+				severity: 5,
+				type: 'ERROR',
+				fixable: false
+			}
+		);
+	}
+
+	/**
+	 * Processes the fileObject class property.
+	 *
+	 * This will get the file contents of the file requested for sniff, and
+	 * then will do syntax checks using Espirma.  The tolerant mode for
+	 * Espirma is on to allow multiple errors to come through if Esprima can
+	 * continue syntax checking.  It's not perfect, but it helps!  Loc is on
+	 * so we can include the col/line nums in our reporter, which are passed
+	 * back to the fileObject.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return {Promise|fileObject} A promise for the fileObject passed in the constructor.
+	 */
+	process() {
+		return new Promise( ( resolve, reject ) => {
+			fetch( this.path )
+				.then( response => response.text() )
+				.then( data => {
+					const errors = esprima.parse( data,
+						{
+							tolerant: true,
+							loc: true
+						}
+					).errors;
+
+					for ( let error of errors ) {
+						this.format( error );
+					}
+				})
+				.catch( error => this.format( error ) )
+				.finally( () => this.fileObject.errors && resolve( this.fileObject ) );
+		});
+	}
+}
+
+export default SniffJs;

--- a/src/admin-menus/class-sniff-page.php
+++ b/src/admin-menus/class-sniff-page.php
@@ -48,7 +48,7 @@ final class Sniff_Page extends Base_Admin_Menu {
 		$sniffer_page_script = new Script_Asset(
 			self::JS_HANDLE,
 			self::JS_URI,
-			[ 'jquery' ],
+			[ 'jquery', 'esprima' ],
 			false,
 			Script_Asset::ENQUEUE_FOOTER
 		);

--- a/src/callback/class-run-sniffer-callback.php
+++ b/src/callback/class-run-sniffer-callback.php
@@ -497,7 +497,9 @@ final class Run_Sniffer_Callback extends Base_Ajax_Callback {
 		$files  = [];
 
 		foreach ( $total_files as $file_path => $file_sniff_results ) {
-			if ( $file_sniff_results[ self::ERRORS ] === 0 && $file_sniff_results[ self::WARNINGS ] === 0 ) {
+
+			// Allow the file list to pass any .js through for further handling, and remove all others with no errors or warnings.
+			if ( substr( $file_path, -3 ) !== '.js' && ( $file_sniff_results[ self::ERRORS ] === 0 && $file_sniff_results[ self::WARNINGS ] === 0 ) ) {
 				continue;
 			}
 
@@ -545,7 +547,7 @@ final class Run_Sniffer_Callback extends Base_Ajax_Callback {
 		$config_args = [ '-s', '-p' ];
 
 		if ( $show_warnings === '0' ) {
-			$config_args = [ '-s', '-p', '-n' ];
+			$config_args[] = [ '-n' ];
 		}
 
 		$runner->config = new Config( $config_args );

--- a/src/callback/class-run-sniffer-callback.php
+++ b/src/callback/class-run-sniffer-callback.php
@@ -547,7 +547,7 @@ final class Run_Sniffer_Callback extends Base_Ajax_Callback {
 		$config_args = [ '-s', '-p' ];
 
 		if ( $show_warnings === '0' ) {
-			$config_args[] = [ '-n' ];
+			$config_args[] = '-n';
 		}
 
 		$runner->config = new Config( $config_args );

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -164,7 +164,7 @@ module.exports = [
 
 		externals: {
 			jquery: 'jQuery',
-			espirma: 'esprima'
+			esprima: 'esprima'
 		},
 
 		optimization: allOptimizations,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -163,7 +163,8 @@ module.exports = [
 		},
 
 		externals: {
-			jquery: 'jQuery'
+			jquery: 'jQuery',
+			espirma: 'esprima'
 		},
 
 		optimization: allOptimizations,


### PR DESCRIPTION
As mentioned by @joyously in https://github.com/WPTRT/theme-sniffer/issues/81#issuecomment-466798094, this PR adds the syntax checking done by core in the editor windows.  Unfortunately eslint isn't entirely stable to run in the browser, but at least a minimal syntax check on js is fitting for this plugin and review process.

In this PR the checks are done still using the filtering on minified files from php in the callback, and the checks happen on the callback return, so after PHPCS runs.  

To test:
1 create a file called test.js and throw it in the twentyninteen theme, with the content from [Esprima's validate demo](http://esprima.org/demo/validate.html).
2 run theme check on twentyninteen theme.  You should get output towards the end of the report similar to this:
![image](https://user-images.githubusercontent.com/11907254/54149862-8c435f80-440d-11e9-9651-db1bab4a3c80.png)

Thoughts:
1. Ideally we should setup a worker pool and handle processing for the js files outside of the main thread as they could have a potentially large amount of files.
2. This only was made for the standard "visual" reporter, and not the raw output.
3.  I'm not sure that PHPCS needs to actually do anything with the JS files.  We could offload some of the lints from PHPCS into Esprima (if there are any from https://github.com/WPTRT/WPThemeReview ).  In testing Esprima is able to handle creating an AST on minfied and large files better than what we get from PHPCS crashing and/or memory issues.  Since phpcs isn't running workers since there's a custom runner this could help alleviate those out of memory checks, and we wouldn't have to perform the file contents checks.
4. Since ultimately we would probably want to get eslint browser compatible, it might be ideal to instead use https://github.com/eslint/espree - initially a fork of esprima(now built on acron), and the parser used in eslint.  I figured for the time being, using the core provided functionality suffices.