### PR TITLE
fixes #149

### DIFF
--- a/src/class-plugin.php
+++ b/src/class-plugin.php
@@ -53,6 +53,11 @@ final class Plugin implements Registerable, Has_Activation, Has_Deactivation {
 	 * @throws Exception\Plugin_Activation_Failure If a condition for plugin activation isn't met.
 	 */
 	public function activate() {
+		if ( ! is_callable( 'shell_exec' ) || false !== stripos( ini_get( 'disable_functions' ), 'shell_exec' ) ) {
+			$error_message = esc_html__( 'Theme Sniffer requires shell_exec to be enabled to function.', 'theme-sniffer' );
+			throw Exception\Plugin_Activation_Failure::activation_message( $error_message );
+		};
+
 		if ( ! function_exists( 'is_plugin_active_for_network' ) ) {
 			include_once ABSPATH . '/wp-admin/includes/plugin.php';
 		}


### PR DESCRIPTION
to test you need to disable shell_exec in your environment.  

These are instructions for using the latest VVV running php7.2-fpm, which may or may not be how you do it in your own environment:

1. Disable Theme Sniffer
2. run this command:
```
vagrant ssh && echo "disable_functions=exec,passthru,shell_exec,system,proc_open,popen,curl_exec,curl_multi_exec,parse_ini_file,show_source" | sudo tee --append /etc/php/7.2/fpm/conf.d/99-security.ini && sudo service php7.2-fpm restart
```
The disabled_functions is just a common set of disabled functions hosts usually add to make it more realistic of an environment.
3. After you've sshed into vagrant, written the security rule, and php-fpm has restarted, go back to dashboard and activate Theme Sniffer.

As a result you should see an admin notice with the fatal displayed:
![image](https://user-images.githubusercontent.com/11907254/54875213-e7436200-4dd0-11e9-8012-abf3762bbd94.png)

Afterwards, you may want to remove this and restart php-fpm to go back to how things were:
```
sudo rm -rf /etc/php/7.2/fpm/conf.d/99-security.ini && sudo service php7.2-fpm restart
```