### PR TITLE
closes #146, fixes #155

### DIFF
--- a/src/admin-menus/class-sniff-page.php
+++ b/src/admin-menus/class-sniff-page.php
@@ -146,8 +146,9 @@ final class Sniff_Page extends Base_Admin_Menu {
 			$atts['error'] = esc_html( $e->getMessage() );
 		}
 
-		$atts['standards']    = $this->get_wpcs_standards();
-		$atts['php_versions'] = $this->get_php_versions();
+		$atts['standards']           = $this->get_wpcs_standards();
+		$atts['php_versions']        = $this->get_php_versions();
+		$atts['minimum_php_version'] = $this->get_minimum_php_version();
 
 		return $atts;
 	}

--- a/src/helpers/sniffer-helpers-trait.php
+++ b/src/helpers/sniffer-helpers-trait.php
@@ -162,4 +162,135 @@ trait Sniffer_Helpers {
 			'TextDomain',
 		];
 	}
+
+	/**
+	 * Check WP Core's Required PHP Version
+	 *
+	 * The functionality to check WP core wasn't added until 5.1.0, so this will
+	 * address users who are on older WP versions and fetch from the API.  The
+	 * code is copied from the core function wp_check_php_version.
+	 *
+	 * @link https://developer.wordpress.org/reference/functions/wp_check_php_version/
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string|false $response String containing minimum PHP version required for user's install of WP. False on failure.
+	 */
+	public function get_wp_minimum_php_version() {
+		if ( function_exists( 'wp_check_php_version' ) ) {
+			$response = wp_check_php_version();
+		} else {
+			$version = phpversion();
+			$key     = md5( $version );
+
+			$response = get_site_transient( 'php_check_' . $key );
+			if ( false === $response ) {
+				$url = 'http://api.wordpress.org/core/serve-happy/1.0/';
+				if ( wp_http_supports( array( 'ssl' ) ) ) {
+					$url = set_url_scheme( $url, 'https' );
+				}
+
+				$url = add_query_arg( 'php_version', $version, $url );
+
+				$response = wp_remote_get( $url );
+
+				if ( is_wp_error( $response ) || 200 !== wp_remote_retrieve_response_code( $response ) ) {
+					return false;
+				}
+
+				/**
+				 * Response should be an array with:
+				 *  'recommended_version' - string - The PHP version recommended by WordPress.
+				 *  'is_supported' - boolean - Whether the PHP version is actively supported.
+				 *  'is_secure' - boolean - Whether the PHP version receives security updates.
+				 *  'is_acceptable' - boolean - Whether the PHP version is still acceptable for WordPress.
+				 */
+				$response = json_decode( wp_remote_retrieve_body( $response ), true );
+
+				if ( ! is_array( $response ) ) {
+					return false;
+				}
+
+				set_site_transient( 'php_check_' . $key, $response, WEEK_IN_SECONDS );
+			}
+
+			if ( isset( $response['is_acceptable'] ) && $response['is_acceptable'] ) {
+				/**
+				 * Filters whether the active PHP version is considered acceptable by WordPress.
+				 *
+				 * Returning false will trigger a PHP version warning to show up in the admin dashboard to administrators.
+				 *
+				 * This filter is only run if the wordpress.org Serve Happy API considers the PHP version acceptable, ensuring
+				 * that this filter can only make this check stricter, but not loosen it.
+				 *
+				 * @since 5.1.1
+				 *
+				 * @param bool   $is_acceptable Whether the PHP version is considered acceptable. Default true.
+				 * @param string $version       PHP version checked.
+				 */
+				$response['is_acceptable'] = (bool) apply_filters( 'wp_is_php_version_acceptable', true, $version );
+			}
+		}
+
+		if ( ! isset( $response['minimum_version'] ) ) {
+			return false;
+		}
+
+		return $response['minimum_version'];
+	}
+
+	/**
+	 * Helper method to get the minimum PHP version supplied by theme
+	 * or the WP core default.
+	 *
+	 * @since 1.1.0
+	 *
+	 * @return string Minimum PHP Version String.
+	 */
+	public function get_minimum_php_version() {
+
+		// WP Core minimum PHP version - only used for fallback if API fails, and no transient stored.
+		$minimum_php_version = '5.2';
+
+		// Check API for minimum WP core version supported.
+		$php_check = $this->get_wp_minimum_php_version();
+
+		// Checks response success or transient data.
+		if ( $php_check !== false ) {
+			$minimum_php_version = $php_check;
+		}
+
+		$readme = wp_normalize_path( get_template_directory() . '/readme.txt' );
+
+		if ( file_exists( $readme ) ) {
+
+			// Check if theme has set minimum PHP version in it's readme.txt file.
+			$theme_php_version = get_file_data( $readme, [ 'minimum_php_version' => 'Requires PHP' ] );
+
+			// Theme has provided an override to minimum PHP version defined by WP Core.
+			if ( ! empty( $theme_php_version['minimum_php_version'] ) ) {
+				$minimum_php_version = $theme_php_version['minimum_php_version'];
+			}
+		}
+
+		// Theme Sniffer's supported PHP version strings are X.X format.
+		$minimum_php_version = substr( $minimum_php_version, 0, 3 );
+
+		// Check Theme Sniffer's supported PHP Versions and find closest PHP version.
+		$supported_php_version  = null;
+		$theme_sniffer_versions = $this->get_php_versions();
+
+		foreach ( $theme_sniffer_versions as $php_version ) {
+			if ( $supported_php_version === null || abs( $minimum_php_version - $supported_php_version ) > abs( $php_version - $minimum_php_version ) ) {
+				$supported_php_version = $php_version;
+			}
+		}
+
+		// Ensure a supported version was found or just use the minimum PHP version determined appropriate.
+		if ( $supported_php_version !== null ) {
+			$minimum_php_version = $supported_php_version;
+		}
+
+		return $minimum_php_version;
+	}
 }

--- a/views/theme-sniffer-page.php
+++ b/views/theme-sniffer-page.php
@@ -11,8 +11,6 @@
 
 namespace Theme_Sniffer\Views;
 
-use Theme_Sniffer\Admin\Helpers;
-
 // Check for errors.
 if ( ! empty( $this->error ) ) {
 	?>
@@ -35,7 +33,7 @@ if ( empty( $themes ) ) {
 
 // Predefined values.
 $current_theme       = get_stylesheet();
-$minimum_php_version = '5.2';
+$minimum_php_version = $this->minimum_php_version;
 $hide_warning        = 0;
 $raw_output          = 0;
 $ignore_annotations  = 0;


### PR DESCRIPTION
This PR adds support for minimum PHP versions and preselecting the one based on the theme's specifications, or WP Core version they are using.

It does the following:
1. Preselect the minimum PHP Version if it's provided by a theme in the theme's `readme.txt` using the format supported for plugins' `readme.txt`. ex: `Requires PHP: 5.4`
2. This will check for the transient data stored by `wp_version_check()` in `php_check_{$key}`.  This function was a more recent addition to core (5.1), so the code was included for the actual API call if the function doesn't exist.  This will allow us to still get an appropriate required PHP version for the core WP version the user is on as a response without relying on that WP version+ until enough time has passed.
3. If unable to communicate with wp.org API then it will use `5.2` as the minimum.   I think WP 5.5 would be the point in which we could fully get rid of 5.2 from Theme Sniffer since themes can support 3 major WordPress versions for backwards compat, and we should continue to provide sniffs for that code at least until that point.

I believe this solution will start to get authors to declare their minimum required PHP version via their `readme.txt`, so this is something that I think is a good thing.  This should also help signal to reviewers what to look for.  Currently with this PR using WP 5.1.1, if the theme doesn't supply a required PHP version, the preselected option will be `5.2` based on the WP.org api call, which returns `5.2.4`.  If you see a different version, then that means the author has declared a higher PHP version in their `readme.txt`, so you should check the entry points for PHP compatibility up until they perform a version check.

Once WP 5.2 rolls out, then the default selected option from the API call to core will preselect the option for `5.6` if the user updates their WP version, and hasn't specified in their readme.txt that they are supporting `5.2`.

As a question though @carolinan and @dingo-d do you think that this should rely on the API call alone instead of the transient cached via php_check for the particular install, or call first to get latest WP version, and use that?  I didn't think about that until now, but it may be a worthwhile addition to prevent any confusion if people are switching between various WP versions.  This would force the minimum required version (if not overridden by theme `readme.txt`) to always preselect based on the latest core release.  The advantage the current way has is that it's based on the WP version the user is currently running, which seems more useful from the aspect of this running as a plugin for authors who might be using it for things other than wp.org repo submissions, and enforcing coding standards on custom themes for sites that they can't update WP core versions on for whatever reason.  Not really sure of all the scenarios that exist, or which method is better, so if you guys have preference let me know and I can make some changes.
